### PR TITLE
Restore Python 3.5 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,18 @@ environment:
     secure: A6ZaqP7tk1HfcTFRqGY/xP4nFZkNtSqXkq/zGGn84qim1HnD0vsVViC+f7fdvFNzNawwcX02WQyo9daVsFszLufliCcpjkbBiXwo4W4t/uPYqbHZuNHI5K1H5pTsPc8Yin+hKcuhYp3Wr2HCMti23muh9GnSDcoeybnfiiJlNoW+ntCg7AkpUiYCGWJfHG4wDbw2cQPWKq7dCFAh/HLAlR4Ccq9MNz5Bol7QDkBzHW5Lxc6HLbXRrLhUkkYr1KCp0qsSLmMHaWshDDzP6I2lcQ==
 
   matrix:
+    - PYTHON: "C:\\Python35"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python36"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_ARCH: "64"
+
     - PYTHON: "C:\\Python37"
       PYTHON_ARCH: "32"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ dist: xenial
 language: python
 
 python:
+  - "3.5"
+  - "3.6"
   - "3.7"
   - "3.8"
   - "3.9"

--- a/heatshrink2/streams.py
+++ b/heatshrink2/streams.py
@@ -129,10 +129,11 @@ class _DecompressReader(io.RawIOBase):
 
             offset += self._size
         else:
-            raise ValueError(f'Invalid value for whence: {whence}')
+            raise ValueError('Invalid value for whence: {}'.format(whence))
 
         if offset < 0:
-            raise IOError(f'[Error {errno.EINVAL}] {os.strerror(errno.EINVAL)}')
+            raise IOError('[Error {code}] {msg}'.format(code=errno.EINVAL,
+                                                        msg=os.strerror(errno.EINVAL)))
 
         # Make it so that offset is the number of bytes to skip forward.
         if offset < self._pos:


### PR DESCRIPTION
There are some environments (older Debians, Raspbian) that still uses
Python 3.5.